### PR TITLE
Push footer to bottom

### DIFF
--- a/css/Style.css
+++ b/css/Style.css
@@ -3,6 +3,9 @@
 }
 body {
   background-color: #ffffff;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  height: 100vh;
 }
 /*  */
 img {


### PR DESCRIPTION
#64 

The footer now rests at the bottom. I notice as I zoom out in the browser or look at it in on a mobile/tablet device, the spacing between the rows gets more pronounced, as a result of `.py-3`. I don't know if this is a behavior you want. Please let me know if you want me to make further changes to adjust this.