### PR TITLE
Fixed the banner from getting the clicks.

### DIFF
--- a/css/Style.css
+++ b/css/Style.css
@@ -20,6 +20,10 @@ img {
   height: 300px;
 }
 
+.header-img.img-fluid {
+  cursor: default;
+}
+
 .img-fluid {
   border-radius: 15px;
   cursor: pointer;

--- a/script.js
+++ b/script.js
@@ -11,6 +11,8 @@ let imagesLength = img.length;
 
 for (i = 0; i < imagesLength; i++) {
   img[i].onclick = function() {
+    if (this.classList.contains("header-img"))
+      return false;
     modal.style.display = "block";
     modalImg.src = this.src;
     document.querySelector("body").style.overflow = "hidden";


### PR DESCRIPTION
Fixed the header image from getting clicks by checking the class name and returning `false` if it has the class `header-img`.

Fixes #77.