### PR TITLE
banner unclickable & no-hover - issue #77

### DIFF
--- a/SimplePics.html
+++ b/SimplePics.html
@@ -17,7 +17,7 @@
     </div>
     <div class="row">
       <div class="col">
-        <img src="images/1080x453.png" alt="banner" class="img-fluid header-img" style="height: 300px; width: 715px;">
+        <img src="images/1080x453.png" alt="banner" class="header-img">
       </div>
     </div>
 

--- a/css/Style.css
+++ b/css/Style.css
@@ -131,4 +131,8 @@ img {
   .modal-content {
     width: 100%;
   }
+
+  .header-img {
+    height: 200px;
+  }
 }


### PR DESCRIPTION
removed the `.img-fluid` class from banner image to remove `hover` property and *pointer cursor*. Added media query css for proper scaling of banner image.